### PR TITLE
Only close context if it's set

### DIFF
--- a/Game/GameRoot.cs
+++ b/Game/GameRoot.cs
@@ -108,7 +108,7 @@ namespace GameProject {
 
         protected override void UnloadContent() {
             #if SDLWINDOWS
-            if (_logContext.HCtx != 0) {
+            if (_logContext is not null && _logContext.HCtx != 0) {
                 _logContext.Close();
             }
             #endif


### PR DESCRIPTION
For me `Wintab32.dll` is not found and thus `_logContext` is not initialized/set. This results in a `NullReferenceException` in `GameRoot.UnloadContent`. This PR adds a check to only close the context if it's set.