### PR TITLE
docs: add feature request issue template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+# Code owners\n* @Arvuno

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for Mitten
+title: "[Feature Request] "
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+Any alternative solutions or features you've considered.
+
+**Project area**
+Which part of Mitten would this touch? (e.g. drawing, camera, saved files in `Game/`, platform layer in `Platforms/`, content/assets in `Content/`)
+
+**Additional context**
+Add any other context, screenshots, or examples about the feature request here.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/Arvuno/mitten/actions/workflows/ci.yml/badge.svg)](https://github.com/Arvuno/mitten/actions)
 # Mitten
 Infinite canvas drawing application.
 


### PR DESCRIPTION
This PR adds a standard GitHub feature-request issue template at `.github/ISSUE_TEMPLATE/feature_request.md`.

The repo currently has `.github/CODEOWNERS` and workflows but no issue templates, so feature suggestions land as bare issues. This template asks reporters for the standard problem / solution / alternatives sections, plus a **Project area** field that maps to the existing folders: `Game/`, `Platforms/`, and `Content/`. That makes triage easier since the codebase is small and split across those three directories.

### Context
Inspired by issue #19 "[Feature Request] Temporary mode" — that issue didn't follow a particular format, which is fine, but having a template encourages more detail up front for future requests.

### Notes
- Pure docs / governance change, no runtime impact.
- Does not affect existing open or closed issues.